### PR TITLE
Add Signup Page

### DIFF
--- a/client/src/components/Auth.tsx
+++ b/client/src/components/Auth.tsx
@@ -1,0 +1,33 @@
+import { CircleX } from 'lucide-react'
+
+function ErrorAlert({ message }: { message: string }) {
+  return (
+    <div role="alert" className="alert alert-error">
+      <CircleX />
+      <span>Error: {message}</span>
+    </div>
+  )
+}
+
+function SubmitButton({ loading }: { loading: boolean }) {
+  return (
+    <div className="card-actions mt-4">
+      <button
+        type="submit"
+        className="btn btn-primary w-full"
+        disabled={loading}
+      >
+        {loading ? (
+          <>
+            <span className="loading loading-spinner loading-sm text-primary"></span>
+            <span className="ml-2 text-primary">Creating account...</span>
+          </>
+        ) : (
+          'Sign Up'
+        )}
+      </button>
+    </div>
+  )
+}
+
+export { ErrorAlert, SubmitButton }

--- a/client/src/lib/auth-client.ts
+++ b/client/src/lib/auth-client.ts
@@ -1,0 +1,3 @@
+import { createAuthClient } from 'better-auth/react'
+
+export const authClient = createAuthClient()

--- a/client/src/routeTree.gen.ts
+++ b/client/src/routeTree.gen.ts
@@ -10,12 +10,18 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as TodosRouteImport } from './routes/todos'
+import { Route as SignupRouteImport } from './routes/signup'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as DemoTanstackQueryRouteImport } from './routes/demo.tanstack-query'
 
 const TodosRoute = TodosRouteImport.update({
   id: '/todos',
   path: '/todos',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const SignupRoute = SignupRouteImport.update({
+  id: '/signup',
+  path: '/signup',
   getParentRoute: () => rootRouteImport,
 } as any)
 const IndexRoute = IndexRouteImport.update({
@@ -31,30 +37,34 @@ const DemoTanstackQueryRoute = DemoTanstackQueryRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/signup': typeof SignupRoute
   '/todos': typeof TodosRoute
   '/demo/tanstack-query': typeof DemoTanstackQueryRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/signup': typeof SignupRoute
   '/todos': typeof TodosRoute
   '/demo/tanstack-query': typeof DemoTanstackQueryRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/signup': typeof SignupRoute
   '/todos': typeof TodosRoute
   '/demo/tanstack-query': typeof DemoTanstackQueryRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/todos' | '/demo/tanstack-query'
+  fullPaths: '/' | '/signup' | '/todos' | '/demo/tanstack-query'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/todos' | '/demo/tanstack-query'
-  id: '__root__' | '/' | '/todos' | '/demo/tanstack-query'
+  to: '/' | '/signup' | '/todos' | '/demo/tanstack-query'
+  id: '__root__' | '/' | '/signup' | '/todos' | '/demo/tanstack-query'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  SignupRoute: typeof SignupRoute
   TodosRoute: typeof TodosRoute
   DemoTanstackQueryRoute: typeof DemoTanstackQueryRoute
 }
@@ -66,6 +76,13 @@ declare module '@tanstack/react-router' {
       path: '/todos'
       fullPath: '/todos'
       preLoaderRoute: typeof TodosRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/signup': {
+      id: '/signup'
+      path: '/signup'
+      fullPath: '/signup'
+      preLoaderRoute: typeof SignupRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/': {
@@ -87,6 +104,7 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  SignupRoute: SignupRoute,
   TodosRoute: TodosRoute,
   DemoTanstackQueryRoute: DemoTanstackQueryRoute,
 }

--- a/client/src/routeTree.gen.ts
+++ b/client/src/routeTree.gen.ts
@@ -11,6 +11,7 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as TodosRouteImport } from './routes/todos'
 import { Route as SignupRouteImport } from './routes/signup'
+import { Route as SigninRouteImport } from './routes/signin'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as DemoTanstackQueryRouteImport } from './routes/demo.tanstack-query'
 
@@ -22,6 +23,11 @@ const TodosRoute = TodosRouteImport.update({
 const SignupRoute = SignupRouteImport.update({
   id: '/signup',
   path: '/signup',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const SigninRoute = SigninRouteImport.update({
+  id: '/signin',
+  path: '/signin',
   getParentRoute: () => rootRouteImport,
 } as any)
 const IndexRoute = IndexRouteImport.update({
@@ -37,12 +43,14 @@ const DemoTanstackQueryRoute = DemoTanstackQueryRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/signin': typeof SigninRoute
   '/signup': typeof SignupRoute
   '/todos': typeof TodosRoute
   '/demo/tanstack-query': typeof DemoTanstackQueryRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/signin': typeof SigninRoute
   '/signup': typeof SignupRoute
   '/todos': typeof TodosRoute
   '/demo/tanstack-query': typeof DemoTanstackQueryRoute
@@ -50,20 +58,28 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/signin': typeof SigninRoute
   '/signup': typeof SignupRoute
   '/todos': typeof TodosRoute
   '/demo/tanstack-query': typeof DemoTanstackQueryRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/signup' | '/todos' | '/demo/tanstack-query'
+  fullPaths: '/' | '/signin' | '/signup' | '/todos' | '/demo/tanstack-query'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/signup' | '/todos' | '/demo/tanstack-query'
-  id: '__root__' | '/' | '/signup' | '/todos' | '/demo/tanstack-query'
+  to: '/' | '/signin' | '/signup' | '/todos' | '/demo/tanstack-query'
+  id:
+    | '__root__'
+    | '/'
+    | '/signin'
+    | '/signup'
+    | '/todos'
+    | '/demo/tanstack-query'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  SigninRoute: typeof SigninRoute
   SignupRoute: typeof SignupRoute
   TodosRoute: typeof TodosRoute
   DemoTanstackQueryRoute: typeof DemoTanstackQueryRoute
@@ -85,6 +101,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof SignupRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/signin': {
+      id: '/signin'
+      path: '/signin'
+      fullPath: '/signin'
+      preLoaderRoute: typeof SigninRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/': {
       id: '/'
       path: '/'
@@ -104,6 +127,7 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  SigninRoute: SigninRoute,
   SignupRoute: SignupRoute,
   TodosRoute: TodosRoute,
   DemoTanstackQueryRoute: DemoTanstackQueryRoute,

--- a/client/src/routes/signin.tsx
+++ b/client/src/routes/signin.tsx
@@ -1,0 +1,9 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/signin')({
+  component: RouteComponent,
+})
+
+function RouteComponent() {
+  return <div>Hello "/signin"!</div>
+}

--- a/client/src/routes/signup.tsx
+++ b/client/src/routes/signup.tsx
@@ -1,0 +1,9 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/signup')({
+  component: RouteComponent,
+})
+
+function RouteComponent() {
+  return <div>Hello "/signup"!</div>
+}

--- a/client/src/routes/signup.tsx
+++ b/client/src/routes/signup.tsx
@@ -1,9 +1,231 @@
-import { createFileRoute } from '@tanstack/react-router'
+import { createFileRoute, Link, useRouter } from '@tanstack/react-router'
+import { KeyRoundIcon, MailIcon, UserIcon } from 'lucide-react'
+import { useEffect, useState } from 'react'
+
+import { ErrorAlert, SubmitButton } from '@/components/Auth'
+import { authClient } from '@/lib/auth-client'
 
 export const Route = createFileRoute('/signup')({
-  component: RouteComponent,
+  component: SignupPage,
 })
 
-function RouteComponent() {
-  return <div>Hello "/signup"!</div>
+interface FormData {
+  name: string
+  email: string
+  password: string
+  confirmPassword: string
+}
+
+interface FormErrors {
+  name?: string
+  email?: string
+  password?: string
+  confirmPassword?: string
+  general?: string
+}
+
+const INITIAL_FORM_DATA: FormData = {
+  name: '',
+  email: '',
+  password: '',
+  confirmPassword: '',
+}
+
+const VALIDATION_RULES = {
+  name: {
+    minLength: 3,
+    maxLength: 30,
+    pattern: /^[A-Za-z][A-Za-z\-]*$/,
+    message: '3 to 30 characters, only letters or dashes',
+  },
+  password: {
+    minLength: 8,
+    message: 'Must be at least 8 characters long',
+  },
+}
+
+function SignupPage() {
+  const router = useRouter()
+  const { data: session } = authClient.useSession()
+  const [formData, setFormData] = useState<FormData>(INITIAL_FORM_DATA)
+  const [errors, setErrors] = useState<FormErrors>({})
+  const [loading, setLoading] = useState(false)
+
+  // Redirect authenticated users
+  useEffect(() => {
+    if (session) {
+      router.navigate({ to: '/todos' })
+    }
+  }, [session, router])
+
+  const validateForm = (): boolean => {
+    const newErrors: FormErrors = {}
+
+    // Validate name
+    if (!formData.name) {
+      newErrors.name = 'Name is required'
+    } else if (!VALIDATION_RULES.name.pattern.test(formData.name)) {
+      newErrors.name = VALIDATION_RULES.name.message
+    } else if (
+      formData.name.length < VALIDATION_RULES.name.minLength ||
+      formData.name.length > VALIDATION_RULES.name.maxLength
+    ) {
+      newErrors.name = VALIDATION_RULES.name.message
+    }
+
+    // Validate email
+    if (!formData.email) {
+      newErrors.email = 'Email is required'
+    } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(formData.email)) {
+      newErrors.email = 'Please enter a valid email address'
+    }
+
+    // Validate password
+    if (!formData.password) {
+      newErrors.password = 'Password is required'
+    } else if (formData.password.length < VALIDATION_RULES.password.minLength) {
+      newErrors.password = VALIDATION_RULES.password.message
+    }
+
+    // Validate confirm password
+    if (!formData.confirmPassword) {
+      newErrors.confirmPassword = 'Please confirm your password'
+    } else if (formData.password !== formData.confirmPassword) {
+      newErrors.confirmPassword = 'Passwords do not match'
+    }
+
+    setErrors(newErrors)
+    return Object.keys(newErrors).length === 0
+  }
+
+  const handleInputChange =
+    (field: keyof FormData) => (e: React.ChangeEvent<HTMLInputElement>) => {
+      const value = e.target.value
+      setFormData((prev) => ({ ...prev, [field]: value }))
+
+      // Clear field-specific error when user starts typing
+      if (errors[field]) {
+        setErrors((prev) => ({ ...prev, [field]: undefined }))
+      }
+    }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+
+    if (!validateForm()) {
+      return
+    }
+
+    setLoading(true)
+    setErrors({})
+
+    try {
+      await authClient.signUp.email({
+        name: formData.name,
+        email: formData.email,
+        password: formData.password,
+      })
+
+      router.navigate({ to: '/todos' })
+    } catch (err) {
+      console.error('Signup failed:', err)
+      setErrors({
+        general: 'Failed to create account. Please try again.',
+      })
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const renderFormField = (
+    field: keyof FormData,
+    type: string,
+    placeholder: string,
+    icon: React.ReactNode,
+    extraProps?: Record<string, any>,
+  ) => (
+    <div className="mt-3 first:mt-0">
+      <label
+        className={`input validator ${errors[field] ? 'input-error' : ''}`}
+      >
+        {icon}
+        <input
+          id={field}
+          type={type}
+          placeholder={placeholder}
+          required
+          value={formData[field]}
+          onChange={handleInputChange(field)}
+          disabled={loading}
+          {...extraProps}
+        />
+      </label>
+      {errors[field] && (
+        <p className="text-error text-sm mt-1">{errors[field]}</p>
+      )}
+    </div>
+  )
+
+  // Don't render anything while checking session
+  if (session) {
+    return null
+  }
+
+  return (
+    <div className="flex items-center justify-center bg-base-100 pt-12">
+      <div className="card bg-base-300 max-w-md">
+        <div className="card-body p-8">
+          <div className="card-title text-3xl px-4">Create an Account</div>
+          <p className="text-base-content/70 my-2 text-center">
+            Sign up to get started
+          </p>
+
+          {errors.general && <ErrorAlert message={errors.general} />}
+          {errors.confirmPassword && (
+            <ErrorAlert message={errors.confirmPassword} />
+          )}
+
+          <form onSubmit={handleSubmit} noValidate>
+            {renderFormField('name', 'text', 'Full Name', <UserIcon />, {
+              minLength: VALIDATION_RULES.name.minLength,
+              maxLength: VALIDATION_RULES.name.maxLength,
+            })}
+
+            {renderFormField('email', 'email', 'mail@site.com', <MailIcon />)}
+
+            {renderFormField(
+              'password',
+              'password',
+              'Password',
+              <KeyRoundIcon />,
+              {
+                minLength: VALIDATION_RULES.password.minLength,
+              },
+            )}
+
+            {renderFormField(
+              'confirmPassword',
+              'password',
+              'Confirm Password',
+              <KeyRoundIcon />,
+              {
+                minLength: VALIDATION_RULES.password.minLength,
+              },
+            )}
+
+            <SubmitButton loading={loading} />
+
+            <div className="mt-6 text-center">
+              <p className="text-base-content/70">
+                Already have an account?{' '}
+                <Link to="/signin" className="link link-primary">
+                  Sign in
+                </Link>
+              </p>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  )
 }

--- a/client/src/routes/todos.tsx
+++ b/client/src/routes/todos.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
 import { createFileRoute } from '@tanstack/react-router'
-import { CircleX } from 'lucide-react'
 
+import { ErrorAlert } from '@/components/Auth'
 import type { AppType } from '@server/index'
 import { hc } from 'hono/client'
 
@@ -32,18 +32,9 @@ function RouteComponent() {
     ))
   }
 
-  const ErrorAlert = () => {
-    return (
-      <div className="alert alert-error" role="alert">
-        <CircleX />
-        <span>{error?.message}</span>
-      </div>
-    )
-  }
-
   return (
     <div className="flex flex-col items-center p-10">
-      {isError && <ErrorAlert />}
+      {isError && <ErrorAlert message={error?.message} />}
       <div className="space-y-3 p-6">
         {isLoading && Array.from({ length: 2 }).map(() => <Loading />)}
         {data &&


### PR DESCRIPTION
- [x] Email/Password login
    - [x] Input validation
    - [x] Name input
    - [x] Confirm password
    - [x]  Better auth client to signup
    - [x] handle submit logic
- [x] Redirect to `/todos` on sign-up
- [x] Redirect to `/todos` if already signed-in
- [x] Loading state
- [x] Error state
- [x] Already have and account? Link to sign-in

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added /signup route with a full signup page: name, email, password, and confirm password fields, inline validation, clear error messages, and loading state. Redirects authenticated users to the todos page after success.
  - Added /signin route (initial placeholder).
  - Introduced shared ErrorAlert and a loading-aware Submit button for consistent UI feedback.

- Refactor
  - Unified error handling in the todos page to use the shared ErrorAlert component for consistent styling and messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->